### PR TITLE
Fixes crash which was caused by empty round information

### DIFF
--- a/scraper/parser.go
+++ b/scraper/parser.go
@@ -181,7 +181,10 @@ func parseSectionEntry(entryStr string) EventEntry {
 	re := regexp.MustCompile(` *([A-Z\*]) *([0-9]+)* *`)
 	for _, part := range parts[3 : len(parts)-1] {
 		result := re.FindStringSubmatch(part)
-
+		if len(result) != 3 {
+			// If the round information is empty, there is nothing to process for this round
+			continue
+		}
 		// Many entries like F, U, B, X do not need an opponent. So we will assign that as default
 		// and fetch the opponent only if it is present.
 		player2 := 0

--- a/scraper/parser_test.go
+++ b/scraper/parser_test.go
@@ -87,6 +87,25 @@ func TestParseSectionEntryForNoRating(t *testing.T) {
 	testParseSectionEntry(t, entryStr, expectedEntry)
 }
 
+func TestParseSectionEntryForFideEventAdjustmentAndEmptyGame(t *testing.T) {
+	entryStr := "    1 | JOHN DAVID BARTHOLOMEW          |5.5  |W2048|W2175|D2672|W2226|L2606|W2263|L2502|W2344|    |\n" +
+		"   MN | 12718516 / R: 2541   ->2552     |     |     |     |     |     |     |     |     |     |     |"
+	expectedEntry := EventEntry{1, 5.5, 12718516, "John David Bartholomew", "MN",
+		[]RatingChange{
+			{"R", "2541", "2552"},
+		}, []Game{
+			{"W", 1, 0, 2048, 0},
+			{"W", 1, 0, 2175, 0},
+			{"D", 1, 0, 2672, 0},
+			{"W", 1, 0, 2226, 0},
+			{"L", 1, 0, 2606, 0},
+			{"W", 1, 0, 2263, 0},
+			{"L", 1, 0, 2502, 0},
+			{"W", 1, 0, 2344, 0},
+		}}
+	testParseSectionEntry(t, entryStr, expectedEntry)
+}
+
 // Convinience function for the above tests.
 func testParseSectionEntry(t *testing.T, entryStr string, expectedEntry EventEntry) {
 	entry := parseSectionEntry(entryStr)


### PR DESCRIPTION
Fixes #8. If the round information was empty, it caused the scraper to fail with index out of range error.