### PR TITLE
Fixing issue where uscf id was empty

### DIFF
--- a/scraper/parser.go
+++ b/scraper/parser.go
@@ -208,10 +208,14 @@ func parseSectionEntry(entryStr string) EventEntry {
 	entry.state = strings.TrimSpace(parts[0])
 
 	// Col 1
-	re = regexp.MustCompile(` *([0-9]+)[ /]+([A-Z]+)*[: ]*([0-9A-Za-z]+)*[ \->]*([0-9Pp]*)`)
+	re = regexp.MustCompile(` *([0-9]*)[ /]+([A-Z]+)*[: ]*([0-9A-Za-z]+)*[ \->]*([0-9Pp]*)`)
 	result := re.FindStringSubmatch(parts[1])
-	entry.id, err = strconv.Atoi(result[1])
-	utils.CheckErr(err)
+	if result[1] != "" {
+		entry.id, err = strconv.Atoi(result[1])
+		utils.CheckErr(err)
+	} else {
+		entry.id = 0
+	}
 	ratingChange := RatingChange{result[2], result[3], result[4]}
 	entry.change = append(entry.change, ratingChange)
 

--- a/scraper/parser_test.go
+++ b/scraper/parser_test.go
@@ -106,6 +106,20 @@ func TestParseSectionEntryForFideEventAdjustmentAndEmptyGame(t *testing.T) {
 	testParseSectionEntry(t, entryStr, expectedEntry)
 }
 
+func TestParseSectionEntryForUnknownNameAndUscfId(t *testing.T) {
+	entryStr := "    2 |                                 |1.0  |L   1|L   4|W   3|\n" +
+		"NJ |          / R: 1827   ->1782     |     |     |     |     |"
+	expectedEntry := EventEntry{2, 1.0, 0, "", "NJ",
+		[]RatingChange{
+			{"R", "1827", "1782"},
+		}, []Game{
+			{"L", 2, 0, 1, 0},
+			{"L", 2, 0, 4, 0},
+			{"W", 2, 0, 3, 0},
+		}}
+	testParseSectionEntry(t, entryStr, expectedEntry)
+}
+
 // Convinience function for the above tests.
 func testParseSectionEntry(t *testing.T, entryStr string, expectedEntry EventEntry) {
 	entry := parseSectionEntry(entryStr)


### PR DESCRIPTION
Fixing an issue where the uscf id and name were both empty. I currently assigned this to uscd id 0. This will allow the rest of the logic to work without any change. Fixes #5 